### PR TITLE
Bug Fix - Safely Unpipe Injects if BotAction might be piped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ New Docs Site published with updated README's for better distribution.
  - Assembling BotAction's via `Factories` replaced with `Assembly Lines`
 
 ### Performance Improvements
+ - Assembled BotAction's of length 1 resolves faster
 
 ### Breaking Changes
  - All uses of `BotActionsChainFactory()` is replaced with `chain()` BotAction

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botmation",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "A TypeScript library for using Puppeteer with a declarative syntax in composing web crawler automation",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botmation",
-  "version": "2.1.1",
+  "version": "2.1.0",
   "description": "A simple TypeScript framework for building composable web bots declaratively with Puppeteer",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "botmation",
   "version": "2.1.1",
-  "description": "A TypeScript library for using Puppeteer with a declarative syntax in composing web crawler automation",
+  "description": "A simple TypeScript framework for building composable web bots declaratively with Puppeteer",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "homepage": "https://botmation.dev",

--- a/src/botmation/actions/cookies.ts
+++ b/src/botmation/actions/cookies.ts
@@ -4,6 +4,7 @@ import { BotFilesAction } from '../interfaces/bot-actions'
 import { enrichBotFileOptionsWithDefaults } from '../helpers/files'
 import { BotFileOptions } from '../interfaces'
 import { getFileUrl } from '../helpers/files'
+import { unpipeInjects } from 'botmation/helpers/pipe'
 
 /**
  * @description   Parse page's cookies and save them as JSON in a local file
@@ -13,13 +14,16 @@ import { getFileUrl } from '../helpers/files'
  * @param fileName 
  * @example saveCookies('cookies') -> creates `cookies.json`
  */
-export const saveCookies = (fileName: string, botFileOptions?: Partial<BotFileOptions>): BotFilesAction => async(page, options) => {
-  // botFileOptions is higher order param that overwrites injected options
-  const hydratedOptions = enrichBotFileOptionsWithDefaults({...options, ...botFileOptions})
-  
-  const cookies = await page.cookies()
-  await fs.writeFile(getFileUrl(hydratedOptions.cookies_directory, hydratedOptions, fileName) + '.json', JSON.stringify(cookies, null, 2))
-}
+export const saveCookies = (fileName: string, botFileOptions?: Partial<BotFileOptions>): BotFilesAction => 
+  async(page, ...injects) => {
+    const [,injectedOptions] = unpipeInjects(injects, 1)
+
+    // botFileOptions is higher order param that overwrites injected options
+    const hydratedOptions = enrichBotFileOptionsWithDefaults({...injectedOptions, ...botFileOptions})
+    
+    const cookies = await page.cookies()
+    await fs.writeFile(getFileUrl(hydratedOptions.cookies_directory, hydratedOptions, fileName) + '.json', JSON.stringify(cookies, null, 2))
+  }
 
 /**
  * @description   Parse the file created with saveCookies() into cookies to load into the page
@@ -29,14 +33,17 @@ export const saveCookies = (fileName: string, botFileOptions?: Partial<BotFileOp
  * @param fileName 
  * @example loadCookies('cookies')
  */
-export const loadCookies = (fileName: string, botFileOptions?: Partial<BotFileOptions>): BotFilesAction => async(page, options) => {
-  // botFileOptions overwrites injected options
-  const hydratedOptions = enrichBotFileOptionsWithDefaults({...options, ...botFileOptions})
+export const loadCookies = (fileName: string, botFileOptions?: Partial<BotFileOptions>): BotFilesAction => 
+  async(page, ...injects) => {
+    const [,injectedOptions] = unpipeInjects(injects, 1)
 
-  const file = await fs.readFile(getFileUrl(hydratedOptions.cookies_directory, hydratedOptions, fileName) + '.json')
-  const cookies = JSON.parse(file.toString())
+    // botFileOptions is higher order param that overwrites injected options
+    const hydratedOptions = enrichBotFileOptionsWithDefaults({...injectedOptions, ...botFileOptions})
 
-  for (const cookie of cookies) {
-    await page.setCookie(cookie)
+    const file = await fs.readFile(getFileUrl(hydratedOptions.cookies_directory, hydratedOptions, fileName) + '.json')
+    const cookies = JSON.parse(file.toString())
+
+    for (const cookie of cookies) {
+      await page.setCookie(cookie)
+    }
   }
-}

--- a/src/botmation/actions/scrapers.ts
+++ b/src/botmation/actions/scrapers.ts
@@ -31,17 +31,20 @@ export const htmlParser = (htmlParser: Function) =>
  * @param htmlSelector 
  */
 export const $ = <R = CheerioStatic>(htmlSelector: string, higherOrderHTMLParser?: Function): ScraperBotAction<R> => 
-  async(page, injectedHTMLParser) => {
+  async(page, ...injects) => {
     let parser: Function
 
-    if (!higherOrderHTMLParser) {
+    // Future support piping the HTML selector with higher-order overriding
+    const [,injectedHTMLParser] = unpipeInjects(injects, 1)
+
+    if (higherOrderHTMLParser) {
+      parser = higherOrderHTMLParser
+    } else {
       if (injectedHTMLParser) {
         parser = injectedHTMLParser
       } else {
         parser = cheerio.load
       }
-    } else {
-      parser = higherOrderHTMLParser
     }
 
     const scrapedHTML = await page.evaluate(getElementOuterHTML, htmlSelector)

--- a/src/botmation/sites/linkedin/actions/auth.ts
+++ b/src/botmation/sites/linkedin/actions/auth.ts
@@ -8,7 +8,8 @@ import {
   type,
   log,
   getLocalStorageItem,
-  map
+  map,
+  errors
 } from '../../..'
 
 /**
@@ -49,12 +50,14 @@ export const isLoggedIn: ConditionalBotAction = pipe()(
  */
 export const login = (emailOrPhone: string, password: string): BotAction =>
   chain(
-    goTo('https://www.linkedin.com/login'),
-    click('form input[id="username"]'),
-    type(emailOrPhone),
-    click('form input[id="password"]'),
-    type(password),
-    click('form button[type="submit"]'),
-    waitForNavigation,
-    log('LinkedIn Login Complete')
+    errors('LinkedIn login()')(
+      goTo('https://www.linkedin.com/login'),
+      click('form input[id="username"]'),
+      type(emailOrPhone),
+      click('form input[id="password"]'),
+      type(password),
+      click('form button[type="submit"]'),
+      waitForNavigation,
+      log('LinkedIn Login Complete')
+    )
   )

--- a/src/examples/linkedin.ts
+++ b/src/examples/linkedin.ts
@@ -57,7 +57,7 @@ const generateTimeStamp = (): string => {
     wait(5000), // tons of stuff loads... no rush
 
     givenThat(isLoggedIn)(
-      toggleMessagingOverlay, // be default, loads in open state
+      toggleMessagingOverlay, // by default, Messaging Overlay loads in open state
       screenshot(generateTimeStamp()), // filename ie "2020-8-21-13-20.png"
       
       // likeAllFrom('Peter Parker', 'Harry Potter'),


### PR DESCRIPTION
- basically the bug was found in scrapers during an example experiment
  that the case of no inject, but running in a pipe, therefore there is
  at least 1 inject, pipe object which was not accounted for
   - fix unpipeInjects() to safely get what you are looking for
- effects files, cookies