### PR TITLE
forAll()() cb & pipe value [...params] update

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Build Status](https://travis-ci.com/mrWh1te/Botmation.svg?branch=master)](https://travis-ci.com/mrWh1te/Botmation)
 [![Known Vulnerabilities](https://snyk.io/test/github/mrWh1te/Botmation/badge.svg?targetFile=package.json)](https://snyk.io/test/github/mrWh1te/Botmation?targetFile=package.json)
 [![codecov](https://img.shields.io/codecov/c/github/mrWh1te/Botmation/master?label=codecov)](https://codecov.io/gh/mrWh1te/Botmation)
-[![LGTM Grade](https://img.shields.io/lgtm/grade/javascript/github/mrWh1te/Botmation)](https://lgtm.com/projects/g/mrWh1te/Botmation)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=mrWh1te_Botmation&metric=alert_status)](https://sonarcloud.io/dashboard?id=mrWh1te_Botmation)
 [![dependencies Status](https://david-dm.org/mrWh1te/Botmation/status.svg)](https://david-dm.org/mrWh1te/Botmation)
 ![GitHub](https://img.shields.io/github/license/mrWh1te/Botmation)
 

--- a/src/botmation/actions/assembly-lines.ts
+++ b/src/botmation/actions/assembly-lines.ts
@@ -26,16 +26,14 @@ export const chain =
       // but, could that be desirable? A new kind of assembly line, similar to chain but carries a Pipe through (1 case ignoring BotAction returns, the other piping those return values)
       if (injectsHavePipe(injects)) {
         // remove pipe
-        if (actions.length === 0) {}
-        else if(actions.length === 1) {
+        if(actions.length === 1) {
           await actions[0](page, ...injects.splice(0, injects.length - 1))
         } else {
           await chainRunner(...actions)(page, ...injects.splice(0, injects.length - 1))
         }
       } else {
         // run regularly in a chain, no need to remove a pipe (last inject)
-        if (actions.length === 0) {}
-        else if(actions.length === 1) {
+        if(actions.length === 1) {
           await actions[0](page, ...injects)
         } else {
           await chainRunner(...actions)(page, ...injects)
@@ -99,8 +97,7 @@ export const assemblyLine =
           }
         } else {
           // running a chain
-          if (actions.length === 0) {}
-          else if (actions.length === 1) {
+          if (actions.length === 1) {
             await actions[0](page, ...injects)
           } else {
             await chainRunner(...actions)(page, ...injects)
@@ -151,21 +148,21 @@ export const pipeRunner =
   (...actions: BotAction<PipeValue|void>[]): BotAction<PipeValue<R>> =>
     async(page, ...injects) => {
       // Possible for last inject to be the piped value
-      let pipe: Pipe = createEmptyPipe()
+      let pipeObject: Pipe = createEmptyPipe()
 
       // in case we are used in a chain, injects won't have a pipe at the end
       if (injectsHavePipe(injects)) {
-        pipe = getInjectsPipeOrEmptyPipe<P>(injects)
+        pipeObject = getInjectsPipeOrEmptyPipe<P>(injects)
         injects = injects.slice(0, injects.length - 1)
       }
 
       // let piped // pipe's are closed chain-links, so nothing pipeable comes in, so data is grabbed in a pipe and shared down stream a pipe, and returns
       for(const action of actions) {
-        const nextPipeValueOrUndefined: PipeValue|void = await action(page, ...injects, pipe) // typing.. botaction's async return can be void, but given how promises must resolve(), the value is actually undefined
+        const nextPipeValueOrUndefined: PipeValue|void = await action(page, ...injects, pipeObject) // typing.. botaction's async return can be void, but given how promises must resolve(), the value is actually undefined
 
         // Bot Actions return the value removed from the pipe, and BotActionsPipe wraps it for injecting
-        pipe = wrapValueInPipe(nextPipeValueOrUndefined as PipeValue|undefined)
+        pipeObject = wrapValueInPipe(nextPipeValueOrUndefined as PipeValue|undefined)
       }
 
-      return pipe.value as any as PipeValue<R>
+      return pipeObject.value as any as PipeValue<R>
     }    

--- a/src/botmation/actions/assembly-lines.ts
+++ b/src/botmation/actions/assembly-lines.ts
@@ -8,11 +8,6 @@ import {
 } from "../helpers/pipe"
 import { PipeValue } from "../types/pipe-value"
 
-//
-// These functions resolve the actions (aka run them), in order received, like on an assembly line, 1 action at a time - going down the conveyer belt
-//
-
-
 /**
  * @description     chain() BotAction for running a chain of BotAction's safely and optimized
  *                  If it receives a Pipe in the injects, it will strip it out. It does not return values.

--- a/src/botmation/actions/console.ts
+++ b/src/botmation/actions/console.ts
@@ -40,9 +40,9 @@ export const log = <R = void>(message?: string): BotAction<R> => async (page, ..
  *                Forwards any Pipe value received by returning it
  * @param message 
  */
-export const warning = <R = void>(warning?: string): BotAction<R> => async (page, ...injects) => {
-  if (warning) {
-    logWarning(warning)
+export const warning = <R = void>(warningMessage?: string): BotAction<R> => async (page, ...injects) => {
+  if (warningMessage) {
+    logWarning(warningMessage)
   }
 
   if (injectsHavePipe(injects)) {
@@ -58,9 +58,9 @@ export const warning = <R = void>(warning?: string): BotAction<R> => async (page
  *                Forwards any Pipe value received by returning it
  * @param message 
  */
-export const error = <R = void>(error?: string): BotAction<R> => async (page, ...injects) => {
-  if (error) {
-    logError(error)
+export const error = <R = void>(errorMessage?: string): BotAction<R> => async (page, ...injects) => {
+  if (errorMessage) {
+    logError(errorMessage)
   }
 
   if (injectsHavePipe(injects)) {

--- a/src/botmation/actions/scrapers.ts
+++ b/src/botmation/actions/scrapers.ts
@@ -11,7 +11,6 @@ import { errors } from '../actions/errors'
 import { getElementOuterHTML, getElementsOuterHTML } from '../helpers/scrapers'
 import { unpipeInjects } from '../helpers/pipe'
 import { pipe } from './assembly-lines'
-import { logMessage } from 'botmation/helpers/console'
 
 /**
  * @description   Inject htmlParser for ScraperBotAction's

--- a/src/botmation/actions/scrapers.ts
+++ b/src/botmation/actions/scrapers.ts
@@ -15,12 +15,12 @@ import { pipe } from './assembly-lines'
 /**
  * @description   Inject htmlParser for ScraperBotAction's
  *                
- * @param htmlParser 
+ * @param htmlParserFunction 
  */
-export const htmlParser = (htmlParser: Function) =>
+export const htmlParser = (htmlParserFunction: Function) =>
   (...actions: BotAction[]): BotAction => 
     pipe()(
-      inject(htmlParser)(
+      inject(htmlParserFunction)(
         errors('htmlParser()()')(...actions)
       )
     )

--- a/src/botmation/actions/utilities.ts
+++ b/src/botmation/actions/utilities.ts
@@ -8,6 +8,7 @@ import { ConditionalBotAction, BotAction } from '../interfaces/bot-actions'
 import { pipeInjects, getInjectsPipeValue, removePipe, wrapValueInPipe } from '../helpers/pipe'
 import { pipeActionOrActions, pipe } from './assembly-lines'
 import { logWarning } from '../helpers/console'
+import { Collection, isDictionary } from '../types/objects'
 
 /**
  * @description Higher Order BotAction that accepts a ConditionalBotAction (pipeable, that returns a boolean) and based on what boolean it resolves,
@@ -27,11 +28,22 @@ export const givenThat =
 
 /**
  * @future support piping in the `collection`
- * @description   A forEach method to loop a collection of (array or object with key/value pairs), to run a loop of piped actions with each iteration of the collection
+ * @description   A forEach method to loop a collection (array or object's key/value pairs) with assembled BotActions in a pipe
  * 
  *                Special BotAction that can take an array of stuff or an object of key value pairs (dictionary)
  *                to iterate over while applying the closure (botActionOrActionsFactory) as provided
  *                The closure's purpose is simply to return a BotAction or BotAction[]
+ * 
+ *                The collection can be passed in via higher-order param or as Pipe value. If both are provided, higher-order param is used.
+ * 
+ *                The callback's returned BotAction(s) are called with the three params matching the forEach() callback syntax
+ *                  value, index, array
+ * 
+ *                Since this function supports Dictionaries too, the "index" is casted into a string
+ *                  value, key, collection
+ * 
+ *                When the returned BotAction(s) are ran in a Pipe, the same callback params are wrapped in an array then injected as the Pipe object's value
+ *                  [value, key, collection]
  * 
  *                The original use-case for this concept, was to be able to re-apply a script on multiple websites via a loop
  *                I've seen multiple examples online, of people using Puppeteer to write a script of actions then loop through a list of websites
@@ -47,7 +59,7 @@ export const givenThat =
  * 
  * @example    with a dictionary as the collection, we can iterate key/value pairs in our BotAction's setup ie fill a form with keys being form input selectors and values being what its typed in each
  *  forAll({id: 'google.com', someOtherKey: 'apple.com'})(
- *    (key, siteName) => ([
+ *    (siteName, key) => ([
  *      goTo('http://' + siteName)
  *      screenshot(key + siteName + '-homepage')
  *    ])
@@ -58,96 +70,45 @@ export const givenThat =
  *    (siteName) => goTo('http://' + siteName)
  *  )
  */
-export interface Dictionary {
-  [key: string]: any // key/value pairs
-}
 export const forAll =
-  (collection?: any[] | Dictionary) =>
-    (botActionOrActionsFactory: (...args: any[]) => BotAction<any>[] | BotAction<any>): BotAction =>
+  (collection?: Collection) =>
+    // cb params = iterated value, iterated index/key (casted as string), collection
+    (botActionOrActionsFactory: (...args: [any, string, Collection]) => BotAction<any>[] | BotAction<any>): BotAction =>
       async(page, ...injects) => {
         // the collection can be passed in via higher-order params or Pipe object value
-        // higher-order params trump Pipe object value
+        // higher-order params trump Pipe object value        
         if (!collection) {
           collection = getInjectsPipeValue(injects)
         }
 
         if (!collection) {
           logWarning('Utilities forAll() missing collection')
-          collection = []
+          return
         }
 
-        /* istanbul ignore else  */
         if (Array.isArray(collection)) {
-          // Array
-          for(let i = 0; i < collection.length; i++) {
-            await pipeActionOrActions(botActionOrActionsFactory(collection[i]))(page, ...injects)
-          }
+          for(let index = 0; index < collection.length; index++) {
+            // Update Pipe value for each iteration
+            injects = removePipe(injects)
+            injects.push(wrapValueInPipe([collection[index], index+'', collection])) // for now, all collection keys are cast to "string" for a single type
 
+            // Run cb
+            await pipeActionOrActions(botActionOrActionsFactory(collection[index], index+'', collection))(page, ...injects)
+          }
         } else {
-          // coded for testing coverage bug creating false negative on this branch
-          if (typeof collection === 'object' && collection !== null) {
-            // Dictionary
+          // in case Pipe object value is not a dictionary
+          /* istanbul ignore next */ // line is covered... false positive?
+          if (isDictionary(collection)) {
             for (const [key, value] of Object.entries(collection)) {
-              await pipeActionOrActions(botActionOrActionsFactory(key, value))(page, ...injects)
+              // Update Pipe value for each iteration
+              injects = removePipe(injects)
+              injects.push(wrapValueInPipe([value, collection, key]))
+  
+              // Run cb
+              await pipeActionOrActions(botActionOrActionsFactory(value, key, collection))(page, ...injects)
             }
           }
         }
-      }
-
-/**
- * 
- */
-export type Dictionary2<V = any> = {
-  [key: string]: V 
-}
-/**
- * Dictionaries are non-null objects with at least one key/value
- * @param value 
- */
-export const isDictionary2 = <I = any>(value: any): value is Dictionary2<I> => 
-  typeof value === 'object' && value !== null && Object.keys(value).length > 0
-
-/**
- * 
- * @param collection 
- */
-export const forAll2 =
-  <I = any>(collection?: I[] | Dictionary2<I>) =>
-    (botActionOrActionsFactory: (...args: [I, I[]|Dictionary2<I>, number|string]) => BotAction<any>[] | BotAction<any>): BotAction =>
-      async(page, ...injects) => {
-        // the collection can be passed in via higher-order params or Pipe object value
-        // higher-order params trump Pipe object value
-        if (!collection) {
-          collection = getInjectsPipeValue(injects)
-        }
-
-        if (!collection) {
-          logWarning('Utilities forAll() missing collection')
-          collection = []
-        }
-
-        if (Array.isArray(collection)) {
-          for(let i = 0; i < collection.length; i++) {
-            // Update Pipe value for each iteration
-            injects = removePipe(injects)
-            injects.push(wrapValueInPipe([collection[i], collection, i]))
-
-            // Run cb
-            await pipeActionOrActions(botActionOrActionsFactory(collection[i], collection, i))(page, ...injects)
-          }
-        } 
-        
-        if (isDictionary2<I>(collection)) {
-          for (const [key, value] of Object.entries(collection)) {
-            // Update Pipe value for each iteration
-            injects = removePipe(injects)
-            injects.push(wrapValueInPipe([value, collection, key]))
-
-            // Run cb
-            await pipeActionOrActions(botActionOrActionsFactory(value, collection, key))(page, ...injects)
-          }
-        }
-        
       }
 
 /**

--- a/src/botmation/helpers/indexed-db.ts
+++ b/src/botmation/helpers/indexed-db.ts
@@ -35,7 +35,7 @@ export function setIndexedDBStoreValue(databaseName: string, databaseVersion: nu
         db.transaction(storeName, 'readwrite')
           .objectStore(storeName)
           .put(value, key)
-          .onsuccess = function(this, ev) {
+          .onsuccess = function(this) {
             db.close()
             return resolve()
           }
@@ -70,7 +70,7 @@ export function getIndexedDBStoreValue(databaseName: string, databaseVersion: nu
           .objectStore(storeName)
           .get(key)
   
-          tx.onsuccess = function(this: IDBRequest<any>, ev: Event) {
+          tx.onsuccess = function(this: IDBRequest<any>) {
             const result = this.result // If key isn't found, the result resolved is undefined
             db.close()
             return resolve(result)

--- a/src/botmation/types/objects.ts
+++ b/src/botmation/types/objects.ts
@@ -27,3 +27,22 @@ export const isObjectWithValue = (data: any): data is {value: any} => {
 
   return typeof data === 'object' && data.value !== undefined
 }
+
+/**
+ * Basic Hash-Map type
+ */
+export type Dictionary<V = any> = {
+  [key: string]: V 
+}
+
+/**
+ * Dictionaries are non-null objects with at least one key/value
+ * @param value 
+ */
+export const isDictionary = <V = any>(value: any): value is Dictionary<V> => 
+  typeof value === 'object' && value !== null && !Array.isArray(value) && Object.keys(value).every(key => typeof key === 'string')
+
+/**
+ * Array or Dictionary
+ */
+export type Collection<V = any> = Array<V>|Dictionary<V>

--- a/src/tests/botmation/actions/indexed-db.spec.ts
+++ b/src/tests/botmation/actions/indexed-db.spec.ts
@@ -41,7 +41,7 @@ describe('[Botmation] actions/indexed-db', () => {
 
   it('indexedDBStore()() should set the first few injects as BotIndexedDBInjects from higher order params', async() => {
     const injectsWithoutPipe = [25, 'hi', 'World']
-    let mockPage = {} as any as Page
+    mockPage = {} as any as Page
 
     await indexedDBStore(higherOrderDatabaseName, higherOrderStoreName, higherOrderDatabaseVersion)()(mockPage)
     await indexedDBStore(higherOrderDatabaseName, higherOrderStoreName, higherOrderDatabaseVersion)()(mockPage, ...injectsWithoutPipe)

--- a/src/tests/botmation/actions/utilites.spec.ts
+++ b/src/tests/botmation/actions/utilites.spec.ts
@@ -7,6 +7,7 @@ import { goTo } from 'botmation/actions/navigation'
 
 import { BASE_URL } from 'tests/urls'
 import { BotAction } from 'botmation/interfaces'
+import { Dictionary } from 'botmation'
 
 jest.mock('botmation/helpers/console', () => {
   return {
@@ -118,7 +119,7 @@ describe('[Botmation] actions/utilities', () => {
   })
 
   it('should call the list of Actions for each key->value pair in the object provided', async() => {
-    const keyValuePairs = {
+    const keyValuePairs: Dictionary = {
       'form input[name="username"]': 'example username',
       'form input[name="password"]': 'example password'
     }
@@ -127,7 +128,7 @@ describe('[Botmation] actions/utilities', () => {
     // whose keys are html selectors for form inputs, and the values are strings to type in
     // so it would be one data structure for doing form input[type=text], in one succinct format
     await forAll(keyValuePairs)(
-      (elementSelector, copyToType) => ([
+      (copyToType, elementSelector) => ([
         click(elementSelector),
         type(copyToType)
       ])
@@ -148,7 +149,7 @@ describe('[Botmation] actions/utilities', () => {
     } as any as Page
 
     await forAll()(
-      (elementSelector, copyToType) => ([
+      (copyToType, elementSelector) => ([
         click(elementSelector),
         type(copyToType)
       ])
@@ -163,9 +164,9 @@ describe('[Botmation] actions/utilities', () => {
 
   it('should recognize null is an object not to iterate', async() => {
     await forAll()(
-      (elementSelector, copyToType) => ([
-        click(elementSelector),
-        type(copyToType)
+      (iteratedPiece) => ([
+        click(iteratedPiece),
+        type(iteratedPiece)
       ])
     )(mockPage, {brand:'Pipe', value: null})
     

--- a/src/tests/botmation/helpers/indexed-db.spec.ts
+++ b/src/tests/botmation/helpers/indexed-db.spec.ts
@@ -1,7 +1,6 @@
 require('fake-indexeddb/auto') // mock IndexedDB (all in memory)
 
 import { setIndexedDBStoreValue, getIndexedDBStoreValue } from 'botmation/helpers/indexed-db'
-import { rejects } from 'assert'
 
 /**
  * @description   IndexedDB Helpers
@@ -53,7 +52,7 @@ describe('[Botmation] helpers/indexed-db', () => {
         db.transaction(databaseStoreName, 'readwrite')
           .objectStore(databaseStoreName)
           .put('test-1-value', 'test-1-key')
-          .onsuccess = function(this: IDBRequest<any>, ev: Event) {
+          .onsuccess = function(this: IDBRequest<any>) {
             db.close()
             return resolve()
           }
@@ -86,7 +85,7 @@ describe('[Botmation] helpers/indexed-db', () => {
         db.transaction(databaseStoreName, 'readwrite')
           .objectStore(databaseStoreName)
           .put('test-2-value', 'test-2-key')
-          .onsuccess = function(this: IDBRequest<any>, ev: Event) {
+          .onsuccess = function(this: IDBRequest<any>) {
             db.close()
             return resolve()
           }
@@ -114,7 +113,7 @@ describe('[Botmation] helpers/indexed-db', () => {
       request.onsuccess = function(this, ev) {
         const db = this.result
 
-        db.onerror = function(this, ev) {
+        db.onerror = function(this) {
           db.close()
           return reject('IndexedDB Request DB.onerror()')
         }
@@ -122,7 +121,7 @@ describe('[Botmation] helpers/indexed-db', () => {
         db.transaction(databaseStoreName, 'readwrite')
           .objectStore(databaseStoreName)
           .put('test-3-value', 'test-3-key')
-          .onsuccess = function(this, ev) {
+          .onsuccess = function(this) {
             db.close()
             return resolve()
           }
@@ -150,7 +149,7 @@ describe('[Botmation] helpers/indexed-db', () => {
       request.onsuccess = function(this, ev) {
         const db = this.result
 
-        db.onerror = function(this, ev) {
+        db.onerror = function(this) {
           db.close()
           return reject('IndexedDB Request DB.onerror()')
         }
@@ -158,7 +157,7 @@ describe('[Botmation] helpers/indexed-db', () => {
         db.transaction(databaseStoreName, 'readwrite')
           .objectStore(databaseStoreName)
           .put('test-3-value', 'test-3-key')
-          .onsuccess = function(this, ev) {
+          .onsuccess = function(this) {
             db.close()
             return resolve()
           }
@@ -191,7 +190,7 @@ describe('[Botmation] helpers/indexed-db', () => {
         db.transaction(databaseStoreName, 'readwrite')
           .objectStore(databaseStoreName)
           .put('test-2-value', 'test-2-key')
-          .onsuccess = function(this: IDBRequest<any>, ev: Event) {
+          .onsuccess = function(this: IDBRequest<any>) {
             db.close()
             return resolve()
           }
@@ -219,7 +218,7 @@ describe('[Botmation] helpers/indexed-db', () => {
       request.onsuccess = function(this, ev) {
         const db = this.result
 
-        db.onerror = function(this, ev) {
+        db.onerror = function(this) {
           db.close()
           return reject('IndexedDB Request DB.onerror()')
         }
@@ -227,7 +226,7 @@ describe('[Botmation] helpers/indexed-db', () => {
         db.transaction(databaseStoreName, 'readwrite')
           .objectStore(databaseStoreName)
           .put('test-3-value', 'test-3-key')
-          .onsuccess = function(this, ev) {
+          .onsuccess = function(this) {
             db.close()
             return resolve()
           }
@@ -263,7 +262,7 @@ describe('[Botmation] helpers/indexed-db', () => {
         db.transaction(databaseStoreName, 'readwrite')
           .objectStore(databaseStoreName)
           .put('test-1-value', 'test-1-key')
-          .onsuccess = function(this: IDBRequest<any>, ev: Event) {
+          .onsuccess = function(this: IDBRequest<any>) {
             db.close()
             return resolve()
           }

--- a/src/tests/botmation/types/objects.spec.ts
+++ b/src/tests/botmation/types/objects.spec.ts
@@ -1,4 +1,4 @@
-import { isObjectWithKey, isObjectWithValue } from 'botmation/types/objects'
+import { isObjectWithKey, isObjectWithValue, isDictionary } from 'botmation/types/objects'
 
 /**
  * @description   Generic Object Types to Help
@@ -12,7 +12,7 @@ describe('[Botmation] types/objects', () => {
 
   //
   // Unit Tests
-  it('isObjectWithKey() returns boolean if the provided param is an Object with a property `key` whose value\'s type is string', () => {
+  it('isObjectWithKey() returns boolean true if the provided param is an Object with a property `key` whose value\'s type is string', () => {
     const objectWithKeyString = {key: 'hi'}
     const objectWithKeyEmptyString = {key: ''}
 
@@ -30,7 +30,7 @@ describe('[Botmation] types/objects', () => {
     expect(isObjectWithKey(undefinedValue)).toEqual(false)
   })
 
-  it('isObjectWithValue() returns boolean if the provided param is an Object with a property `value` (type any)', () => {
+  it('isObjectWithValue() returns boolean true if the provided param is an Object with a property `value` (type any)', () => {
     const objectWithValueString = {value: 'hi'}
     const objectWithValueEmptyString = {value: ''}
 
@@ -44,6 +44,29 @@ describe('[Botmation] types/objects', () => {
     expect(isObjectWithValue(objectWithoutValue)).toEqual(false)
     expect(isObjectWithValue(notObject)).toEqual(false)
     expect(isObjectWithValue(undefinedValue)).toEqual(false)
+  })
+
+  it('isDictionary() returns boolean true if the provided param is a Dictionary type', () => {
+    const nullObject = null
+    const array = ['hello', 'world']
+    const func = () => 4
+
+    const dictionary1 = {
+      length: 5,
+      foo: 'bar'
+    }
+    const dictionary2 = {
+      foo: 'bar',
+      hello: 'world',
+      ailubasdf: 'aoihnasdf'
+    }
+
+    expect(isDictionary(nullObject)).toEqual(false)
+    expect(isDictionary(func)).toEqual(false)
+    expect(isDictionary(array)).toEqual(false)
+
+    expect(isDictionary(dictionary1)).toEqual(true)
+    expect(isDictionary(dictionary2)).toEqual(true)
   })
 
 })

--- a/src/tests/server/example.html
+++ b/src/tests/server/example.html
@@ -1,4 +1,5 @@
-<html>
+<!DOCTYPE html>
+<html lang="en">
   <head>
     <title>Testing: Example</title>
   </head>

--- a/src/tests/server/example2.html
+++ b/src/tests/server/example2.html
@@ -1,4 +1,5 @@
-<html>
+<!DOCTYPE html>
+<html lang="en">
   <head>
     <title>Testing: Example 2</title>
   </head>

--- a/src/tests/server/index.html
+++ b/src/tests/server/index.html
@@ -1,4 +1,5 @@
-<html>
+<!DOCTYPE html>
+<html lang="en">
   <head>
     <title>Example Testing Page</title>
   </head>

--- a/src/tests/server/success.html
+++ b/src/tests/server/success.html
@@ -1,4 +1,5 @@
-<html>
+<!DOCTYPE html>
+<html lang="en">
   <head>
     <title>Testing: Form Submit Success</title>
   </head>

--- a/webpack.build.config.js
+++ b/webpack.build.config.js
@@ -45,12 +45,7 @@ module.exports = {
   target: 'node',
   output: {
     path: path.resolve(__dirname, 'build'),
-    filename: (chunkData) => {
-      switch(chunkData.chunk.name) {
-        default:
-          return '[name].js';
-      }
-    },
+    filename: () => '[name].js',
     libraryTarget: 'umd',
     library: 'botmation',
     umdNamedDefine: true


### PR DESCRIPTION
- issue #60
- forAll2 concept
  - stronger typing
    - isDictionary2() type guard
  - cb params adjusted to (collection[index|key], collection, index|key)
  - pipe value adjusted to array of cb params for each iteration
- [x] added CI SonarCloud
   - code smells, code duplications, bugs, tech debt & vulnerability tracking

- [x] tests
- [x] verify with examples