### PR TITLE
pipeCase()() 

### DIFF
--- a/src/botmation/actions/utilities.ts
+++ b/src/botmation/actions/utilities.ts
@@ -12,6 +12,8 @@ import { Collection, isDictionary, Dictionary } from '../types/objects'
 import { PipeValue } from '../types/pipe-value'
 import { AbortLineSignal, isAbortLineSignal } from '../types/abort-signal'
 import { processAbortLineSignal } from '../helpers/abort'
+import { createMatchesSignal } from '../helpers/matches'
+import { MatchesSignal } from '../types/matches-signal'
 
 /**
  * @description Higher Order BotAction that accepts a ConditionalBotAction (pipeable, that returns a boolean) and based on what boolean it resolves,
@@ -215,23 +217,7 @@ export const forAsLong =
  * 
  * 
  */
-export type MatchesSignal<V = any> = {
-  brand: 'Matches_Signal',
-  matches: Dictionary<V>,
-  pipeValue?: PipeValue
-}
 
-export const createMatchesSignal = <V = any>(matches: Dictionary<V> = {}, pipeValue?: PipeValue): MatchesSignal<V> => ({
-  brand: 'Matches_Signal',
-  matches,
-  pipeValue
-})
-
-export const hasMatches = (matches: Dictionary): boolean => 
-  Object.keys(matches).length > 0
-
-export const isMatchesSignal = <V = any>(value: any): value is MatchesSignal<V> => 
-  typeof value === 'object' && value !== null && isDictionary<V>(value.matches)
 
 export const pipeCase = 
   (...valuesToTest: PipeValue[]) =>

--- a/src/botmation/actions/utilities.ts
+++ b/src/botmation/actions/utilities.ts
@@ -214,8 +214,14 @@ export const forAsLong =
       }
 
 /**
- * 
+ * Similar to givenThat except instead of evaluating a BotAction for TRUE, its testing an array of values against the pipe object value for truthy.
+ * A value can be a function. In this case, the function is treated as a callback, expected to return a truthy expression, is passed in the pipe object's value
  * @param valuesToTest 
+ * @return AbortLineSignal|MatchesSignal
+ *  If no matches are found or matches are found, a MatchesSignal is returned
+ *  It is determined if signal has matches by using hasAtLeastOneMatch() helper
+ *  If assembled BotAction aborts(1), it still returns a MatchesSignal with the matches
+ *  If assembled BotAction aborts(2+), it returns a processed AbortLineSignal
  */
 export const pipeCase = 
   (...valuesToTest: PipeValue[]) =>

--- a/src/botmation/actions/utilities.ts
+++ b/src/botmation/actions/utilities.ts
@@ -215,10 +215,8 @@ export const forAsLong =
 
 /**
  * 
- * 
+ * @param valuesToTest 
  */
-
-
 export const pipeCase = 
   (...valuesToTest: PipeValue[]) =>
     (...actions: BotAction[]): BotAction<AbortLineSignal|MatchesSignal> => 

--- a/src/botmation/helpers/matches.ts
+++ b/src/botmation/helpers/matches.ts
@@ -1,11 +1,20 @@
 import { Dictionary, PipeValue } from "../types"
 import { MatchesSignal } from "../types/matches-signal"
 
+/**
+ * 
+ * @param matches 
+ * @param pipeValue 
+ */
 export const createMatchesSignal = <V = any>(matches: Dictionary<V> = {}, pipeValue?: PipeValue): MatchesSignal<V> => ({
   brand: 'Matches_Signal',
   matches,
   pipeValue
 })
 
-export const hasMatches = (matches: Dictionary): boolean => 
-  Object.keys(matches).length > 0
+/**
+ * 
+ * @param signal 
+ */
+export const hasAtLeastOneMatch = (signal: MatchesSignal): boolean => 
+  Object.keys(signal.matches).length > 0

--- a/src/botmation/helpers/matches.ts
+++ b/src/botmation/helpers/matches.ts
@@ -1,0 +1,11 @@
+import { Dictionary, PipeValue } from "../types"
+import { MatchesSignal } from "../types/matches-signal"
+
+export const createMatchesSignal = <V = any>(matches: Dictionary<V> = {}, pipeValue?: PipeValue): MatchesSignal<V> => ({
+  brand: 'Matches_Signal',
+  matches,
+  pipeValue
+})
+
+export const hasMatches = (matches: Dictionary): boolean => 
+  Object.keys(matches).length > 0

--- a/src/botmation/helpers/matches.ts
+++ b/src/botmation/helpers/matches.ts
@@ -2,7 +2,7 @@ import { Dictionary, PipeValue } from "../types"
 import { MatchesSignal } from "../types/matches-signal"
 
 /**
- * 
+ * Create a MatchesSignal object with safe defaults for no params provided (default is no matches, and pipe value undefined)
  * @param matches 
  * @param pipeValue 
  */
@@ -13,7 +13,7 @@ export const createMatchesSignal = <V = any>(matches: Dictionary<V> = {}, pipeVa
 })
 
 /**
- * 
+ * Does the MatchesSignal have at least one match represented?
  * @param signal 
  */
 export const hasAtLeastOneMatch = (signal: MatchesSignal): boolean => 

--- a/src/botmation/types/matches-signal.ts
+++ b/src/botmation/types/matches-signal.ts
@@ -1,0 +1,11 @@
+import { Dictionary, isDictionary } from "./objects"
+import { PipeValue } from "./pipe-value"
+
+export type MatchesSignal<V = any> = {
+  brand: 'Matches_Signal',
+  matches: Dictionary<V>,
+  pipeValue?: PipeValue
+}
+
+export const isMatchesSignal = <V = any>(value: any): value is MatchesSignal<V> => 
+  typeof value === 'object' && value !== null && value.brand === 'Matches_Signal' && isDictionary<V>(value.matches)

--- a/src/botmation/types/matches-signal.ts
+++ b/src/botmation/types/matches-signal.ts
@@ -1,11 +1,18 @@
 import { Dictionary, isDictionary } from "./objects"
 import { PipeValue } from "./pipe-value"
 
+/**
+ * 
+ */
 export type MatchesSignal<V = any> = {
   brand: 'Matches_Signal',
   matches: Dictionary<V>,
   pipeValue?: PipeValue
 }
 
+/**
+ * 
+ * @param value 
+ */
 export const isMatchesSignal = <V = any>(value: any): value is MatchesSignal<V> => 
   typeof value === 'object' && value !== null && value.brand === 'Matches_Signal' && isDictionary<V>(value.matches)

--- a/src/tests/botmation/helpers/matches.spec.ts
+++ b/src/tests/botmation/helpers/matches.spec.ts
@@ -1,0 +1,62 @@
+import { createMatchesSignal, hasAtLeastOneMatch } from 'botmation/helpers/matches'
+
+/**
+ * @description   Matches Helpers
+ */
+describe('[Botmation] helpers/matches', () => {
+  
+  //
+  // Unit Test
+  it('createMatchesSignal() creates a `MatchesSignal` object with safe intuitive defaults if no params are provided to set the object\'s values', () => {
+    const noParams = createMatchesSignal()
+    const overrideSafeDefaultsWithThoseValues = createMatchesSignal({}, undefined)
+    const fiveMatches = createMatchesSignal({'1': 'bear', '2': 'lion', '3': 'bird', '4': 'mountain', '5': 'cloud'})
+    const matchesWithPipeValue = createMatchesSignal({'4': 'cat', '6': 'dog'}, 'test-pipe-value-983')
+
+    const matchesWithNumberKeys = createMatchesSignal({5: 'sfd'}) // serialization will convert them into strings
+
+    expect(noParams).toEqual({
+      brand: 'Matches_Signal',
+      matches: {}
+    })
+    expect(overrideSafeDefaultsWithThoseValues).toEqual({
+      brand: 'Matches_Signal',
+      matches: {}
+    })
+    expect(fiveMatches).toEqual({
+      brand: 'Matches_Signal',
+      matches: {'1': 'bear', '2': 'lion', '3': 'bird', '4': 'mountain', '5': 'cloud'}
+    })
+    expect(matchesWithPipeValue).toEqual({
+      brand: 'Matches_Signal',
+      matches: {'4': 'cat', '6': 'dog'},
+      pipeValue: 'test-pipe-value-983'
+    })
+
+    expect(matchesWithNumberKeys).toEqual({
+      brand: 'Matches_Signal',
+      matches: {'5': 'sfd'}
+    })
+  })
+
+  it('hasAtLeastOneMatch() returns a boolean, TRUE if the provided MatchesSignal has at least one match otherwise FALSE', () => {
+    const signalWithZeroMatches = createMatchesSignal()
+    const signalWithZeroMatchesAndPipeValue = createMatchesSignal({}, 'a pipe vlaue')
+
+    const signalWithOneMatch = createMatchesSignal({8: 'cat'})
+    const signalWithOneMatchAndPipeValue = createMatchesSignal({8: 'cat'}, 'another pipe value')
+
+    const signalWithMultipleMatches = createMatchesSignal({2: 'dog', 93: 'elephant'})
+    const signalWithMultipleMatchesAndPipeValue = createMatchesSignal({2: 'dog', 93: 'elephant'}, 'another another pipe value')
+
+    expect(hasAtLeastOneMatch(signalWithZeroMatches)).toEqual(false)
+    expect(hasAtLeastOneMatch(signalWithZeroMatchesAndPipeValue)).toEqual(false)
+
+    expect(hasAtLeastOneMatch(signalWithOneMatch)).toEqual(true)
+    expect(hasAtLeastOneMatch(signalWithOneMatchAndPipeValue)).toEqual(true)
+    expect(hasAtLeastOneMatch(signalWithMultipleMatches)).toEqual(true)
+    expect(hasAtLeastOneMatch(signalWithMultipleMatchesAndPipeValue)).toEqual(true)
+
+  })
+
+})

--- a/src/tests/botmation/types/abort-signal.spec.ts
+++ b/src/tests/botmation/types/abort-signal.spec.ts
@@ -8,7 +8,7 @@ describe('[Botmation] types/abort-signal', () => {
 
   //
   // Unit Test
-  it('isAbortLineSignal() returns boolean true if the provided param is an Object that matches the minimum requirements for the AbortLineSignal interface', () => {
+  it('isAbortLineSignal() returns boolean true if the provided param is an Object that matches the minimum requirements for the AbortLineSignal type', () => {
     // pass
     const abortLineSignalObj: AbortLineSignal = {
       brand: 'Abort_Signal',

--- a/src/tests/botmation/types/matches-signal.spec.ts
+++ b/src/tests/botmation/types/matches-signal.spec.ts
@@ -1,0 +1,60 @@
+import { MatchesSignal, isMatchesSignal } from 'botmation/types/matches-signal'
+import { wrapValueInPipe } from 'botmation/helpers/pipe'
+
+/**
+ * @description   MatchesSignal Type guard function
+ */
+describe('[Botmation] types/matches-signal', () => {
+
+  //
+  // Unit Test
+  it('isMatchesSignal() returns boolean true if the provided param is an Object that matches the minimum requirements for the MatchesSignal type', () => {
+    // pass
+    const emptyMatchesSignal: MatchesSignal = {
+      brand: 'Matches_Signal',
+      matches: {}
+    }
+    const matchesSignal: MatchesSignal = {
+      brand: 'Matches_Signal',
+      matches: {
+        3: 'dog',
+        7: 'cat'
+      }
+    }
+    const matchesSignalWithPipeValue: MatchesSignal = {
+      brand: 'Matches_Signal',
+      matches: {
+        2: 'bird',
+        17: 'cow'
+      },
+      pipeValue: 'aim for the stars and land on the moon'
+    }
+    
+    // fails
+    const pipeObject = wrapValueInPipe('hey')
+    const likeMatchesSignalButArray = {
+      brand: 'Matches_Signal',
+      matches: []
+    }
+    const likeMatchesSignalButNull = {
+      brand: 'Matches_Signal',
+      matches: null
+    }
+    const likeMatchesSignalButWrongBrand = {
+      brand: 'Matches_Signal_',
+      matches: {}
+    }
+
+    // pass
+    expect(isMatchesSignal(emptyMatchesSignal)).toEqual(true)
+    expect(isMatchesSignal(matchesSignal)).toEqual(true)
+    expect(isMatchesSignal(matchesSignalWithPipeValue)).toEqual(true)
+    
+    // fail
+    expect(isMatchesSignal(pipeObject)).toEqual(false)
+    expect(isMatchesSignal(likeMatchesSignalButArray)).toEqual(false)
+    expect(isMatchesSignal(likeMatchesSignalButNull)).toEqual(false)
+    expect(isMatchesSignal(likeMatchesSignalButWrongBrand)).toEqual(false)
+  })
+
+})


### PR DESCRIPTION
- [x] tests
- [x] helpers 
- [x] pipeCase() BotAction for #38 in consideration of #61 
- [x] abort line signal support
- [x] MatchesSignal 
   - [x] type guard 

- if a value to test in this case() first call is a function, it will be
  used as a callback function with the pipe object value for testing (return truthy expression)
- using one "signal" for matches and no matches that requires an
  additional check of hasMatches() against matches of signal

See https://github.com/mrWh1te/Botmation/pull/56#issuecomment-682166652, https://github.com/mrWh1te/Botmation/pull/56#issuecomment-682069913