### PR TITLE
Fix switchPipe()() bug, missing edge-cases & cleaner code

### DIFF
--- a/src/botmation/actions/assembly-lines.ts
+++ b/src/botmation/actions/assembly-lines.ts
@@ -9,7 +9,7 @@ import {
 } from "../helpers/pipe"
 import { PipeValue } from "../types/pipe-value"
 import { AbortLineSignal, isAbortLineSignal } from "../types/abort-line-signal"
-import { processAbortLineSignal, createAbortLineSignal } from "../helpers/abort"
+import { processAbortLineSignal } from "../helpers/abort"
 import { isMatchesSignal, MatchesSignal } from "botmation/types/matches-signal"
 import { hasAtLeastOneMatch } from "botmation/helpers/matches"
 

--- a/src/botmation/actions/assembly-lines.ts
+++ b/src/botmation/actions/assembly-lines.ts
@@ -177,6 +177,7 @@ export const switchPipe =
               resolvedActionResult = processAbortLineSignal(resolvedActionResult)
             }
 
+            // switchPipe abort behavior
             if (!isAbortLineSignal(resolvedActionResult)) {
               // special case of "0" where the assembledLines was processed from 1->0 which returns the pipeValue
               // don't break the line, simply append abortLineSignal.pipeValue to array
@@ -185,8 +186,9 @@ export const switchPipe =
               actionsResults.push(resolvedActionResult.pipeValue)
               return actionsResults
             } else {
-              // assembledLines 2+
-              return createAbortLineSignal(resolvedActionResult.assembledLines - 1, resolvedActionResult.pipeValue)
+              // assembledLines 2+ - breaks line and breaks returning array functionality
+              // hence returned a processed abort line signal
+              return processAbortLineSignal(resolvedActionResult)
             }
           } else {
             // normal BotAction so add the result to the array to return later

--- a/src/tests/botmation/actions/assembly-lines.spec.ts
+++ b/src/tests/botmation/actions/assembly-lines.spec.ts
@@ -884,6 +884,23 @@ describe('[Botmation] actions/assembly-lines', () => {
     expect(mockToPipeAction).toHaveBeenNthCalledWith(2, {}, wrapValueInPipe(200))
   })
 
+  it('switchPipe() returns an array of results representing a 1:1 relationship with the assembled BotActions unless fully aborted out', async() => {
+    const mockAction1 = jest.fn(() => Promise.resolve('mercury'))
+    const mockAction2 = jest.fn(() => Promise.resolve('venus'))
+    const mockAction3 = jest.fn(() => Promise.resolve('earth'))
+    const mockAction4 = jest.fn(() => Promise.resolve('mars'))
+    const mockActionDoesntRun = jest.fn(() => Promise.resolve('no'))
+
+    await switchPipe(42)(
+      mockAction1,
+      mockAction2,
+      pipeCase(42)(
+        mockAction3
+      ),
+      mockAction4
+    )(mockPage)
+  })
+
   it('switchPipe() supports AbortLineSignal with special behavior where the assembledLines required to abort out of the BotAction is dependent on a MatchesSignal having at least 1 match', async() => {
     const mockActionReturnsFive = jest.fn(() => Promise.resolve(5))
     const mockActionPassThrough = jest.fn((p, pO) => Promise.resolve(pO.value))

--- a/src/tests/botmation/actions/assembly-lines.spec.ts
+++ b/src/tests/botmation/actions/assembly-lines.spec.ts
@@ -5,6 +5,7 @@ import { AbortLineSignal } from 'botmation/types/abort-line-signal'
 import { createEmptyPipe, wrapValueInPipe } from 'botmation/helpers/pipe'
 import { createAbortLineSignal } from 'botmation/helpers/abort'
 import { pipeCase } from 'botmation/actions/pipe'
+import { createMatchesSignal } from 'botmation/helpers/matches'
 
 /**
  * @description   Assembly-Lines BotAction's
@@ -897,49 +898,110 @@ describe('[Botmation] actions/assembly-lines', () => {
       pipeCase(42)(
         mockAction3
       ),
-      mockAction4
+      mockAction4,
+      pipeCase(37)(
+        mockActionDoesntRun
+      ),
+      abort()
     )(mockPage)
   })
 
-  it('switchPipe() supports AbortLineSignal with special behavior where the assembledLines required to abort out of the BotAction is dependent on a MatchesSignal having at least 1 match', async() => {
+  /**
+   * switchPipe abort behavior
+   *
+   *   if an assembled botaction returns an infinite AbortLineSignal(0) then return that
+
+   *   otherwise, if no case matches, process a returned AbortLineSignal by 1 assembledLines (subtract 1 from assembledLines)
+
+   *   then for either no case matches or has matches, upon abortline signal do the following:
+
+   *   0 = dont break line, append abortLineSignal.pipeValue to return array
+   *   1 = break line, append abortLineSignal.pipeValue to return array then return array
+   *   2+ = dont return array, but return an AbortLineSignal( 1+ ) // reduce count by 1
+   */
+  it('switchPipe() supports AbortLineSignal with unique behavior', async() => {
     const mockActionReturnsFive = jest.fn(() => Promise.resolve(5))
-    const mockActionPassThrough = jest.fn((p, pO) => Promise.resolve(pO.value))
 
-    // toPipe is a BotAction that aborts
-    const toPipeBotActionAborts = await switchPipe(abort(1, 'an abort value'))()(mockPage)
-    expect(toPipeBotActionAborts).toEqual('an abort value')
+    // no case matches - AbortLineSignal(0) - break like and return infinity abortline signal
+    const passThroughInfinityAbortsignal = await switchPipe()(
+      abort(0),
+      mockActionReturnsFive
+    )(mockPage)
+    expect(passThroughInfinityAbortsignal).toEqual({
+      brand: 'Abort_Signal',
+      assembledLines: 0
+    })
+    expect(mockActionReturnsFive).not.toHaveBeenCalled()
 
-    // toPipe is Value with assembled BotAction that aborts(1) without a matching case
-    const toPipeValueAbortOne = await switchPipe(8000)(
+    // no case matches - AbortLineSignal 1 = dont break line, append abortLineSignal.pipeValue to return array
+    const abortLineOneNoCaseMatches = await switchPipe()(
+      abort(1, 'abort-1-pipe-value'),
+      mockActionReturnsFive
+    )(mockPage)
+    expect(abortLineOneNoCaseMatches).toEqual(['abort-1-pipe-value', 5])
+    expect(mockActionReturnsFive).toHaveBeenNthCalledWith(1, {}, createEmptyPipe())
+
+    // no case matches - AbortLineSignal 2 = break line, append aLS.pipeValue to array and return that array
+    const abortLineTwoNoCaseMatches = await switchPipe()(
       mockActionReturnsFive,
-      abort(1, 'another abort value')
+      abort(2, 'abort-2-pipe-value'),
+      mockActionReturnsFive
     )(mockPage)
+    expect(abortLineTwoNoCaseMatches).toEqual([5, 'abort-2-pipe-value'])
+    expect(mockActionReturnsFive).toHaveBeenCalledTimes(2)
+    expect(mockActionReturnsFive).not.toHaveBeenCalledTimes(3)
 
-    expect(toPipeValueAbortOne).toEqual([5, 'another abort value']) // no case matching, takes 2
-    expect(mockActionReturnsFive).toHaveBeenNthCalledWith(1, {}, wrapValueInPipe(8000))
-
-    // toPipe is value with assembled BotAction that aborts(2+) without matching case
-    const toPipeValueAbortMulti = await switchPipe(10000)(
-      mockActionPassThrough,
-      abort(7, 'aborted pipe value to check')
+    // no case matches - AbortLineSignal 3+ = break line, but dont return array, instead return processed AbortLineSignal (reduce count by 1)
+    const abortLineThreeNoCaseMatches = await switchPipe()(
+      mockActionReturnsFive,
+      abort(3, 'abort-3-pipe-value'),
+      mockActionReturnsFive
     )(mockPage)
+    expect(abortLineThreeNoCaseMatches).toEqual(createAbortLineSignal(1, 'abort-3-pipe-value')) // 1 to break line return array, 2+ to break line and return abortlinesignal instead of array - hence minus 2
+    expect(mockActionReturnsFive).toHaveBeenCalledTimes(3)
+    expect(mockActionReturnsFive).not.toHaveBeenCalledTimes(4)
 
-    expect(toPipeValueAbortMulti).toEqual(createAbortLineSignal(5, 'aborted pipe value to check'))
-
-    // toPipe is value with assembled BotAction that aborts(1) BUT with matching case so aborts entirely
-    const mockActionDoesntRun = jest.fn(() => Promise.resolve())
-    const toPipeValueAbortOneWithMatchingCase = await switchPipe(300)(
-      abort(), // no matching case, so the following still runs
-      pipeCase(300)(
-        mockActionReturnsFive,
-        mockActionPassThrough
+    //
+    // case matches - abortlinesignal(0) break line and return abortlinesignal infinity instead of array
+    const passThroughInfinityAbortSignalWithMatches = await switchPipe(10)(
+      pipeCase(10)(
+        mockActionReturnsFive
       ),
-      mockActionReturnsFive,
-      abort(1, 'the case was 300'),
-      mockActionDoesntRun
+      abort(0),
+      mockActionReturnsFive
     )(mockPage)
+    expect(passThroughInfinityAbortSignalWithMatches).toEqual({
+      brand: 'Abort_Signal',
+      assembledLines: 0
+    })
+    expect(mockActionReturnsFive).toHaveBeenCalledTimes(4)
+    expect(mockActionReturnsFive).not.toHaveBeenCalledTimes(5)
 
-    expect(toPipeValueAbortOneWithMatchingCase).toEqual('the case was 300')
-    expect(mockActionDoesntRun).not.toHaveBeenCalled()
+    // case matches - abortlinesignal(1) = break line, append abortLineSignal.pipeValue to return array then return array
+    const abortLineOneWithCaseMatches = await switchPipe(10)(
+      pipeCase(10)(
+        mockActionReturnsFive
+      ),
+      abort(1, 'a-pipe-1-value-O_O'),
+      mockActionReturnsFive
+    )(mockPage)
+    expect(abortLineOneWithCaseMatches).toEqual([
+      createMatchesSignal({'0': 10}, 5),
+      'a-pipe-1-value-O_O'
+    ])
+    expect(mockActionReturnsFive).toHaveBeenCalledTimes(5)
+    expect(mockActionReturnsFive).not.toHaveBeenCalledTimes(6)
+
+    // case matches - abortlinesignal(2) = dont return array, but return an AbortLineSignal( 1+ ) // reduce count by 1
+    const abortLineTwoWithCaseMatches = await switchPipe(10)(
+      pipeCase(10)(
+        mockActionReturnsFive
+      ),
+      abort(2, 'a-pipe-2-value-O_O'),
+      mockActionReturnsFive
+    )(mockPage)
+    expect(abortLineTwoWithCaseMatches).toEqual(createAbortLineSignal(1, 'a-pipe-2-value-O_O'))
+    expect(mockActionReturnsFive).toHaveBeenCalledTimes(6)
+    expect(mockActionReturnsFive).not.toHaveBeenCalledTimes(7)
   })
 })


### PR DESCRIPTION
This PR standardizes switchPipe()()'s behavior with abort line signal and fixes the bug with the matches signal

TDD for the win 🎯 

Fix issue #71 

Related https://github.com/mrWh1te/Botmation/issues/71#issuecomment-688413458, https://github.com/mrWh1te/Botmation/issues/71#issuecomment-688460834