### PR TITLE
Major v3 prep

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ Why choose Botmation?
 
 <img alt="Baby Bot" src="https://raw.githubusercontent.com/mrWh1te/Botmation/master/assets/art/baby_bot.PNG" width="125" align="right">
 
-It empowers Puppeteer code with a simple pattern to maximize your code readability, reusability and testability.
+It empowers Puppeteer code with a simple pattern to maximize code readability, reusability and testability.
 
-It has a compositional design with safe defaults for building bots with less code.
+Its compositional design comes pre-built with safe defaults for building bots with less code.
 
 It encourages a learn at your own pace approach to exploring the possibilities of Functional programming.
 
@@ -27,9 +27,9 @@ It has 100% source code test coverage.
 
 # Introduction
 
-[Botmation](https://botmation.dev) is simple functional framework for [Puppeteer](https://github.com/puppeteer/puppeteer) to build online Bots in a composable, testable, and declarative way. It provides a simple pattern focused on a single type of function called `BotAction`. 
+[Botmation](https://botmation.dev) is simple declarative framework for [Puppeteer](https://github.com/puppeteer/puppeteer), to build web bots in a composable way. It provides a simple pattern focused on a single type of function called `BotAction`. 
 
-`BotAction`'s handle almost everything from simple tasks in crawling and scraping the web to logging in & automating your social media. They are composable. They make assembling Bots easy, declarative, and simple.
+`BotAction`'s handle everything from simple tasks in crawling and scraping the web to logging in & automating your social media. They are composable. They make assembling Bots easy, declarative, and simple.
 
 The possibilities are endless!
 
@@ -44,15 +44,12 @@ Install
 
 Install Botmation with `npm` and save it as a dependency:
 
-    npm install -s botmation
+    npm install --save botmation
 
-If you're just getting started, install `puppeteer` latest v2 & `@types/puppeteer` v3.0.0:
+If you're just getting started, install `puppeteer` & `@types/puppeteer`:
 
-    npm install -s puppeteer@">=2.0.0 <3.0.0" @types/puppeteer@3.0.0
-
-While `Botmation` source code works with Puppeteer version 3, 4, and 5, the E2E testing has a bug that is limiting the packaging, as of this moment.
-
-> If you want to use Botmation with the latest Puppeteer version, for now, clone the repo locally and work from the playground bot. From there you can install the latest `@types/puppeteer` and `puppeteer` packages then build Botmation source code with it. But, be wary, the E2E tests will become rather unstable.
+    npm install --save puppeteer 
+    npm install --save-dev @types/puppeteer
 
 Documentation
 -------------
@@ -67,7 +64,7 @@ After intalling through `npm`, import any `BotAction` from the main module:
 import { chain, goTo, screenshot } from 'botmation'
 ```
 
-As of v2.1.x, there are 14 groups of `BotAction` to compose from: 
+As of v3.x, there are 14 groups of `BotAction` to compose from: 
 
 <img alt="Leader Bot" src="https://raw.githubusercontent.com/mrWh1te/Botmation/master/assets/art/red_bot.PNG" width="200" align="right" style="position: relative;top: 30px;">
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botmation",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "description": "A simple TypeScript framework for building composable web bots declaratively with Puppeteer",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,52 +9,11 @@ const CopyPlugin = require('copy-webpack-plugin');
 var nodeExternals = require('webpack-node-externals');
 
 const localSrcBotmationDir = 'src/botmation/';
-const sitesInstagramDir = 'sites/instagram/';
 
 module.exports = {
   entry: {
-    //
-    // Class & Assembly-Lines
-    'index': path.resolve(__dirname, localSrcBotmationDir, 'index.ts'), // barrel
-    //
-    // Interfaces & Types
-    'interfaces': path.resolve(__dirname, localSrcBotmationDir, 'interfaces/index.ts'), // barrel
-    'types': path.resolve(__dirname, localSrcBotmationDir, 'types/index.ts'), // barrel
-    //
-    // Actions
-    'actions/abort': path.resolve(__dirname, localSrcBotmationDir, 'actions/abort.ts'),
-    'actions/assembly-lines': path.resolve(__dirname, localSrcBotmationDir, 'actions/assembly-lines.ts'),
-    'actions/console': path.resolve(__dirname, localSrcBotmationDir, 'actions/console.ts'),
-    'actions/cookies': path.resolve(__dirname, localSrcBotmationDir, 'actions/cookies.ts'),
-    'actions/errors': path.resolve(__dirname, localSrcBotmationDir, 'actions/errors.ts'),
-    'actions/files': path.resolve(__dirname, localSrcBotmationDir, 'actions/files.ts'),
-    'actions/indexed-db': path.resolve(__dirname, localSrcBotmationDir, 'actions/indexed-db.ts'),
-    'actions/input': path.resolve(__dirname, localSrcBotmationDir, 'actions/input.ts'),
-    'actions/local-storage': path.resolve(__dirname, localSrcBotmationDir, 'actions/local-storage.ts'),
-    'actions/navigation': path.resolve(__dirname, localSrcBotmationDir, 'actions/navigation.ts'),
-    'actions/pipe': path.resolve(__dirname, localSrcBotmationDir, 'actions/pipe.ts'),
-    'actions/scrapers': path.resolve(__dirname, localSrcBotmationDir, 'actions/scrapers.ts'),
-    'actions/utilities': path.resolve(__dirname, localSrcBotmationDir, 'actions/utilities.ts'),
-    // 
-    // Helpers
-    'helpers/abort': path.resolve(__dirname, localSrcBotmationDir, 'helpers/abort.ts'),
-    'helpers/cases': path.resolve(__dirname, localSrcBotmationDir, 'helpers/cases.ts'),
-    'helpers/console': path.resolve(__dirname, localSrcBotmationDir, 'helpers/console.ts'),
-    'helpers/files': path.resolve(__dirname, localSrcBotmationDir, 'helpers/files.ts'),
-    'helpers/indexed-db': path.resolve(__dirname, localSrcBotmationDir, 'helpers/indexed-db.ts'),
-    'helpers/local-storage': path.resolve(__dirname, localSrcBotmationDir, 'helpers/local-storage.ts'),
-    'helpers/navigation': path.resolve(__dirname, localSrcBotmationDir, 'helpers/navigation.ts'),
-    'helpers/pipe': path.resolve(__dirname, localSrcBotmationDir, 'helpers/pipe.ts'),
-    'helpers/scrapers': path.resolve(__dirname, localSrcBotmationDir, 'helpers/scrapers.ts'),
-    //
-    // Site Specific
-    // Instagram
-    'sites/instagram/selectors': path.resolve(__dirname, localSrcBotmationDir, sitesInstagramDir, 'selectors.ts'),
-    'sites/instagram/actions/auth': path.resolve(__dirname, localSrcBotmationDir, sitesInstagramDir, 'actions/auth.ts'),
-    'sites/instagram/actions/modals': path.resolve(__dirname, localSrcBotmationDir, sitesInstagramDir, 'actions/modals.ts'),
-    'sites/instagram/constants/modals': path.resolve(__dirname, localSrcBotmationDir, sitesInstagramDir, 'constants/modals.ts'),
-    'sites/instagram/constants/urls': path.resolve(__dirname, localSrcBotmationDir, sitesInstagramDir, 'constants/urls.ts'),
-    'sites/instagram/helpers/urls': path.resolve(__dirname, localSrcBotmationDir, sitesInstagramDir, 'helpers/urls.ts'),
+    // main bundle barrel
+    'index': path.resolve(__dirname, localSrcBotmationDir, 'index.ts')
   },
   module: {
     rules: [
@@ -77,10 +36,6 @@ module.exports = {
     path: path.resolve(__dirname, 'dist'),
     filename: (chunkData) => {
       switch(chunkData.chunk.name) {
-        case 'interfaces':
-          return 'interfaces/index.js';
-        case 'types':
-          return 'types/index.js'
         case 'index':
         default:
           return '[name].js';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -34,12 +34,8 @@ module.exports = {
   },
   output: {
     path: path.resolve(__dirname, 'dist'),
-    filename: (chunkData) => {
-      switch(chunkData.chunk.name) {
-        case 'index':
-        default:
-          return '[name].js';
-      }
+    filename: () => {
+      return '[name].js';
     },
     libraryTarget: 'umd',
     library: 'botmation',


### PR DESCRIPTION
- [x] bundle
   - [x] slimmer
   - [x] no instagram specific botaction's
   - [x] verify locally with test project

- [x] botmation [docs pr](https://github.com/mrWh1te/botmation-docs/pull/23)
   - [x] update message about using specific puppeteer version
   - [x] clean it up -> simplify, simplify, simplify
   - [x] replace coffee shop example with golden chain, add images?

TBD:
 - [ ] publish instagram botaction's in separate npm package with warning that written permission is required to crawl their webapp
 - [ ] publish linkedin botaction's in separate npm package with warning
 - [ ] or instead of that, just keep them posted on the botmation.dev docs site, but add a warning that while it's possible, and probably fine for many cases, if someone tries to make a business out of it, they will breaking a company policy